### PR TITLE
feat(cache): Use 128-bit hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Also, it's written in Rust.
 
 ### Caching
 
-Whenever you run a linter on a file via Lūn, it saves a record (i.e., a hash)
-constructed from  several components, including the file path, file metadata
-(modification time, size, permissions, etc.), and the linter command line (see
-the documentation for a comprehensive list). Before running any tool, Lūn first
+Whenever you run a linter on a file via Lūn, it saves a record constructed from
+several components. These include the file path, file metadata (modification
+time, size, permissions, etc.), and the linter command line (see the
+documentation for a comprehensive list). Before running any tool, Lūn first
 consults this cache to see if it has a corresponding entry. If so, it skips
 running the linter again.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -187,7 +187,7 @@ fn build_tool_stamp(tool: &Tool, cmd: &str, careful: bool) -> Result<tool::Stamp
         hasher.update(value.as_encoded_bytes());
     }
 
-    Ok(tool::Stamp(file::Xxhash(hasher.digest())))
+    Ok(tool::Stamp(file::Xxhash(hasher.digest128())))
 }
 
 fn build_tool_globsets(
@@ -303,7 +303,7 @@ fn build_config_hash(tool: &str, configs: &[PathBuf]) -> Result<Option<file::Xxh
         file::hash_md(path, &metadata, &mut hasher);
         file::hash_mtime(path, &metadata, &mut hasher)?;
     }
-    Ok(Some(file::Xxhash(hasher.digest())))
+    Ok(Some(file::Xxhash(hasher.digest128())))
 }
 
 fn build_files_globset(patterns: &[String], tool_name: &str) -> Result<GlobSet> {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -10,7 +10,7 @@ use crate::tool;
 pub(crate) fn add(cache_file: &Path, string: &str, files: &[PathBuf]) -> Result<(), anyhow::Error> {
     let mut hasher = Xxh3::new();
     hasher.update(string.as_bytes());
-    let tool_stamp = tool::Stamp(file::Xxhash(hasher.digest()));
+    let tool_stamp = tool::Stamp(file::Xxhash(hasher.digest128()));
     let mut cache = HashCache::from_file(cache_file, None)?;
     for file_path in files {
         let file = file::File::new(file_path.clone())
@@ -33,7 +33,7 @@ pub(crate) fn get(
 ) -> Result<(), anyhow::Error> {
     let mut hasher = Xxh3::new();
     hasher.update(string.as_bytes());
-    let tool_stamp = tool::Stamp(file::Xxhash(hasher.digest()));
+    let tool_stamp = tool::Stamp(file::Xxhash(hasher.digest128()));
     let cache = HashCache::from_file(cache_file, None)?;
     for file_path in files {
         let file = file::File::new(file_path.clone())
@@ -56,7 +56,7 @@ pub(crate) fn get(
 pub(crate) fn rm(cache_file: &Path, string: &str, files: &[PathBuf]) -> Result<(), anyhow::Error> {
     let mut hasher = Xxh3::new();
     hasher.update(string.as_bytes());
-    let tool_stamp = tool::Stamp(file::Xxhash(hasher.digest()));
+    let tool_stamp = tool::Stamp(file::Xxhash(hasher.digest128()));
     let mut cache = HashCache::from_file(cache_file, None)?;
     for file_path in files {
         let file = file::File::new(file_path.clone())

--- a/src/file.rs
+++ b/src/file.rs
@@ -9,7 +9,7 @@ use xxhash_rust::xxh3::Xxh3;
 use crate::exec;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub(crate) struct Xxhash(pub(crate) u64);
+pub(crate) struct Xxhash(pub(crate) u128);
 
 /// Hash of file path, content, and metadata
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -39,7 +39,7 @@ pub(crate) fn hash_md(path: &Path, metadata: &fs::Metadata, md: &mut Xxh3) {
 fn compute_md_stamp(path: &Path, metadata: &fs::Metadata) -> Stamp {
     let mut md = Xxh3::new();
     hash_md(path, metadata, &mut md);
-    Stamp(Xxhash(md.digest()))
+    Stamp(Xxhash(md.digest128()))
 }
 
 pub(crate) fn hash_mtime(
@@ -63,7 +63,7 @@ pub(crate) fn hash_mtime(
 fn compute_mtime_stamp(path: &Path, metadata: &fs::Metadata) -> Result<Stamp, anyhow::Error> {
     let mut mtime_hasher = Xxh3::new();
     hash_mtime(path, metadata, &mut mtime_hasher)?;
-    let mtime_stamp = Stamp(Xxhash(mtime_hasher.digest()));
+    let mtime_stamp = Stamp(Xxhash(mtime_hasher.digest128()));
     Ok(mtime_stamp)
 }
 
@@ -100,21 +100,21 @@ impl File {
         if let Some(content_stamp) = self.content_stamp {
             hasher.update(&content_stamp.0.0.to_le_bytes());
         }
-        Stamp(Xxhash(hasher.digest()))
+        Stamp(Xxhash(hasher.digest128()))
     }
 
     pub(crate) fn mtime_stamp(&self) -> Stamp {
         let mut hasher = Xxh3::new();
         hasher.update(&self.metadata_stamp.0.0.to_le_bytes());
         hasher.update(&self.mtime_stamp.0.0.to_le_bytes());
-        Stamp(Xxhash(hasher.digest()))
+        Stamp(Xxhash(hasher.digest128()))
     }
 }
 
 pub(crate) fn compute_hash(content: &[u8]) -> Xxhash {
     let mut hasher = Xxh3::new();
     hasher.update(content);
-    Xxhash(hasher.digest())
+    Xxhash(hasher.digest128())
 }
 
 pub(crate) fn collect_files(

--- a/src/ninja.rs
+++ b/src/ninja.rs
@@ -90,10 +90,10 @@ pub(crate) fn exec(
 
 fn tgt_name(cmd: &cmd::Command) -> String {
     let hash = cmd_hash(cmd);
-    format!("$builddir/{hash:016x}")
+    format!("$builddir/{hash:032x}")
 }
 
-fn cmd_hash(cmd: &cmd::Command) -> u64 {
+fn cmd_hash(cmd: &cmd::Command) -> u128 {
     let mut hasher = Xxh3::new();
     let cmd_obj = cmd.to_command();
     let program_str = cmd_obj.get_program().to_string_lossy();
@@ -109,7 +109,7 @@ fn cmd_hash(cmd: &cmd::Command) -> u64 {
         hasher.update(path_str.as_bytes());
         hasher.update(&[0]);
     }
-    hasher.digest()
+    hasher.digest128()
 }
 
 fn generate_ninja_file(

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -37,7 +37,7 @@ impl TestFile {
         let mut metadata_hasher = Xxh3::new();
         metadata_hasher.update(self.path.as_os_str().as_encoded_bytes());
         metadata_hasher.update(&self.size.to_le_bytes());
-        let metadata_stamp = file::Stamp(file::Xxhash(metadata_hasher.digest()));
+        let metadata_stamp = file::Stamp(file::Xxhash(metadata_hasher.digest128()));
         let mtime_stamp = file::Stamp(file::Xxhash(0));
         let content_stamp = Some(file::Stamp(file::compute_hash(self.content.as_bytes())));
         file::File {


### PR DESCRIPTION
This makes the risk of collision absurdly low.

See the table on this page:
https://en.wikipedia.org/wiki/Birthday_attack

Or analysis here:
https://github.com/Cyan4973/xxHash/wiki/Collision-ratio-comparison

Fixes #42.
