### PR TITLE
feat: More known linters: `bash -n`, `jq null`, `make -n`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- https://keepachangelog.com/en/1.0.0/ -->
 
+## [Unreleased]
+
+- Add `bash -n`, `jq null`, and `make -n` to known linters
+
 ## [0.7.1] - 2026-01-19
 
 [0.7.1]: https://github.com/langston-barrett/lun/releases/tag/v0.7.1

--- a/doc/config.md
+++ b/doc/config.md
@@ -98,8 +98,11 @@ The following tools are recognized by name:
 
 **Linters:**
 
+- `bash -n`
 - `cargo clippy`
 - `hlint`
+- `jq null`
+- `make -n`
 - `mdlynx`
 - `mypy`
 - `ruff check`

--- a/src/known.rs
+++ b/src/known.rs
@@ -6,6 +6,18 @@ pub(crate) fn known_linters() -> Vec<config::Linter> {
     vec![
         config::Linter {
             tool: config::Tool {
+                name: Some(String::from("bash -n")),
+                cmd: "bash -n --".to_string(),
+                files: vec!["*.sh".to_string()],
+                ignore: Vec::new(),
+                granularity: Granularity::Individual,
+                configs: Vec::new(),
+                cd: None,
+            },
+            fix: None,
+        },
+        config::Linter {
+            tool: config::Tool {
                 name: Some(String::from("cargo clippy")),
                 cmd: "cargo clippy --color={{color}} --all-targets -- --deny warnings".to_string(),
                 files: vec!["*.rs".to_string()],
@@ -24,6 +36,30 @@ pub(crate) fn known_linters() -> Vec<config::Linter> {
                 ignore: Vec::new(),
                 granularity: Granularity::Individual,
                 configs: vec![PathBuf::from(".hlint.yml"), PathBuf::from(".hlint.yaml")],
+                cd: None,
+            },
+            fix: None,
+        },
+        config::Linter {
+            tool: config::Tool {
+                name: Some(String::from("jq null")),
+                cmd: "jq null --".to_string(),
+                files: vec!["*.json".to_string()],
+                ignore: Vec::new(),
+                granularity: Granularity::Individual,
+                configs: Vec::new(),
+                cd: None,
+            },
+            fix: None,
+        },
+        config::Linter {
+            tool: config::Tool {
+                name: Some(String::from("make -n")),
+                cmd: "make -n".to_string(),
+                files: vec!["**/Makefile".to_string(), "*.mk".to_string()],
+                ignore: Vec::new(),
+                granularity: Granularity::Batch,
+                configs: Vec::new(),
                 cd: None,
             },
             fix: None,


### PR DESCRIPTION
Fixes #94.
