### PR TITLE
refactor: Pass less of `Cli` to `main::go`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -63,15 +63,16 @@ impl Paths {
 }
 
 pub(crate) fn go(
-    cli: cli::Cli,
+    cmd: cli::Command,
+    warns: cli::warn::WarnOpts,
     paths: &Paths,
     env: &env::Env,
     config: Option<config::Config>,
     out_config: out::Config,
     out: &mut (impl Write + Send),
 ) -> Result<bool> {
-    let lints = warn::warns::Warns::from_cli_and_config(&cli.warn, config.as_ref())?;
-    match &cli.command {
+    let lints = warn::warns::Warns::from_cli_and_config(&warns, config.as_ref())?;
+    match &cmd {
         cli::Command::Cache(cache_cmd) => match &cache_cmd.command {
             cli::CacheCommand::Rm => {
                 cache::rm(&paths.cache)?;
@@ -169,7 +170,15 @@ fn main() -> Result<()> {
         None => None,
     };
     trace!(?config);
-    let ok = go(cli, &paths, &env, config, out_config, &mut io::stderr())?;
+    let ok = go(
+        cli.command,
+        cli.warn,
+        &paths,
+        &env,
+        config,
+        out_config,
+        &mut io::stderr(),
+    )?;
     if !ok {
         process::exit(1);
     }

--- a/src/test/e2e.rs
+++ b/src/test/e2e.rs
@@ -255,7 +255,15 @@ fn run_test(test_path: &Path) -> Result<()> {
 
         // Run with the temp directory as working directory
         let out_config = out::Config::new(&env, cli.log);
-        let result = crate::go(cli, &paths, &env, config, out_config, &mut output_buffer);
+        let result = crate::go(
+            cli.command,
+            cli.warn,
+            &paths,
+            &env,
+            config,
+            out_config,
+            &mut output_buffer,
+        );
 
         // Get captured output and normalize escape sequences
         let captured = {

--- a/src/test/warn.rs
+++ b/src/test/warn.rs
@@ -21,7 +21,16 @@ fn test(flags: &[&'static str], config: &'static str) -> Result<(), anyhow::Erro
     };
     let config = toml::from_str(config).unwrap();
     let out_config = out::Config::new(&env, cli.log);
-    crate::go(cli, &paths, &env, config, out_config, &mut io::sink()).map(|b| assert!(b))
+    crate::go(
+        cli.command,
+        cli.warn,
+        &paths,
+        &env,
+        config,
+        out_config,
+        &mut io::sink(),
+    )
+    .map(|b| assert!(b))
 }
 
 #[test]


### PR DESCRIPTION
Towards #109.
